### PR TITLE
Fix for oculus touch right controller touch/press, and left skeleton

### DIFF
--- a/Assets/VRTK/SteamVR_VRTK_Actions/1/bindings_oculus_touch.json
+++ b/Assets/VRTK/SteamVR_VRTK_Actions/1/bindings_oculus_touch.json
@@ -125,7 +125,7 @@
           }
         },
         {
-          "path": "/user/hand/right/input/x",
+          "path": "/user/hand/right/input/a",
           "mode": "button",
           "parameters": {},
           "inputs": {
@@ -138,22 +138,15 @@
           }
         },
         {
-          "path": "/user/hand/right/input/y",
+          "path": "/user/hand/right/input/b",
           "mode": "button",
           "parameters": {},
           "inputs": {
             "click": {
               "output": "/actions/vrtk/in/buttononeclick"
-            }
-          }
-        },
-        {
-          "path": "/user/hand/right/input/a",
-          "mode": "button",
-          "parameters": {},
-          "inputs": {
-            "click": {
-              "output": "/actions/vrtk/in/buttononeclick"
+            },
+            "touch": {
+              "output": "/actions/vrtk/in/buttononetouch"
             }
           }
         },
@@ -206,10 +199,6 @@
         {
           "output": "/actions/vrtk/in/skeletonrighthand",
           "path": "/user/hand/right/input/skeleton/right"
-        },
-        {
-          "output": "/actions/vrtk/in/skeletonrighthand",
-          "path": "/user/hand/left/input/skeleton/right"
         }
       ]
     }


### PR DESCRIPTION
I think this should fix the oculus touch right controller touch/press. You'll have to try it with a new project as I don't have an oculus available at the moment. I believe the skeleton error you were seeing may be due to a binding error here as well but we'll see. I've made some notes for the binding ui.